### PR TITLE
Remove Unnecessary Off-site Link

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func setActivity() {
 			},
 			{
 				Label: "Add the bot",
-				Url:   "https://christmascountdown.live/discord",
+				Url:   "https://discord.com/oauth2/authorize?client_id=509851616216875019&permissions=537149440&scope=applications.commands%20bot",
 			},
 		},
 	})


### PR DESCRIPTION
This replaces the link to christmascountdown.live which redirects to discord with the discord link it redirects to so people don't have to open an external link and can go through the OAuth flow in their Discord clients.